### PR TITLE
feat: 레이드 종료 api 세분화, 본인 댓글만 종료 프론트 구현

### DIFF
--- a/src/main/java/com/pokewith/mypost/controller/MyPostController.java
+++ b/src/main/java/com/pokewith/mypost/controller/MyPostController.java
@@ -72,6 +72,19 @@ public class MyPostController {
         return myPostService.endRaid(raidId, userId);
     }
 
+    @DeleteMapping("/mypost/comment")
+    @ApiOperation(value = "본인 작성댓글 종료 api", notes = "본인 댓글만 종료하는 api / 초대중인경우 완전종료, 진행중인경우 좋아요싫어요 상태로 변환")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "댓글 종료 성공"),
+            @ApiResponse(code = 400, message = "유효성검사 실패(이미 종료된 댓글)"),
+            @ApiResponse(code = 403, message = "권한 없음")
+    })
+    public ResponseEntity<String> endOneComment(HttpServletRequest request) {
+        log.info("/api/mypost/comment");
+        Long userId = usernameService.getUsername(request);
+        return myPostService.endRaidOneComment(userId);
+    }
+
     @PostMapping("/mypost/vote")
     @ApiOperation(value = "본인 작성글 레이드 종료 후 좋아요 싫어요 api", notes = "레이드 끝난 후 팀원들에게 좋아요 싫어요 주는 api")
     @ApiResponses(value = {
@@ -83,8 +96,6 @@ public class MyPostController {
     public ResponseEntity<String> voteLikeOrDislike(@RequestBody @Valid RqPostLikeAndDislikeDto dto, HttpServletRequest request
             , BindingResult bindingResult) throws BindException {
         log.info("/api/mypost/vote");
-
-        log.info(String.valueOf(dto));
 
         collectionValidation(dto.getLikeAndDislikeDtoList(), bindingResult);
 

--- a/src/main/java/com/pokewith/raid/Raid.java
+++ b/src/main/java/com/pokewith/raid/Raid.java
@@ -84,7 +84,7 @@ public class Raid extends TimeEntity {
         this.raidState = RaidState.VOTE;
     }
 
-    public void voteEndRaid() { this.raidState = RaidState.DONE; }
+    public void finalEndRaid() { this.raidState = RaidState.DONE; }
 
     public void makeChat(String chat) {
         this.chat = chat;

--- a/src/main/java/com/pokewith/raid/repository/RaidCommentQueryRepository.java
+++ b/src/main/java/com/pokewith/raid/repository/RaidCommentQueryRepository.java
@@ -31,7 +31,7 @@ public class RaidCommentQueryRepository {
                 .leftJoin(raidComment.raid, raid).fetchJoin()
                 .leftJoin(raidComment.user, user).fetchJoin()
                 .leftJoin(raid.user, user).fetchJoin()
-                .where(raid.raidId.eq(raidId))
+                .where(raid.raidId.eq(raidId), raidComment.raidCommentState.ne(RaidCommentState.REJECTED))
                 .fetch();
     }
 

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -307,7 +307,7 @@ function allComment(resultData, num) {
   startDiv.setAttribute("class", "card-body commentBody"+num);
 
   for(let i = 0; i<resultData.raidCommentDtoList.length; i++){
-    // if(num === resultData.raidCommentDtoList[i].raidId){
+    if(resultData.raidCommentDtoList[i].raidCommentState === 'WAITING'){
       let commentId = resultData.raidCommentDtoList[i].raidCommentId;
       let commentW = document.createElement("div");
       commentW.setAttribute("class", "commentWrap comment"+commentId);
@@ -324,7 +324,7 @@ function allComment(resultData, num) {
       commentW.innerHTML = commentText;
 
       startDiv.appendChild(commentW);
-    // }
+    }
   }
 
   let commentForm = document.createElement("div");

--- a/src/main/resources/static/js/mypost.js
+++ b/src/main/resources/static/js/mypost.js
@@ -266,7 +266,7 @@ function allComment(num) {
 		currentDiv.appendChild(startDiv);
 
 	  for(let i = 0; i<commentInfo.raidCommentDtoList.length; i++){
-	    if(commentInfo.raidCommentDtoList[i].raidCommentState === 'WAITING'){
+	    if(raidInfo.raidState === 'INVITE'){
 
 			const commentId = commentInfo.raidCommentDtoList[i].raidCommentId;
 			const commentW = document.createElement("div");
@@ -327,23 +327,31 @@ function allComment(num) {
 
 			const deleteIcon = document.createElement("i");
 			deleteIcon.setAttribute("class", "fas fa-times delete");
-			deleteIcon.setAttribute("onClick", "deleteComment("+commentInfo.raidCommentDtoList[i].raidCommentId+", "+num+")");
+			deleteIcon.setAttribute("onClick", "deleteComment()");
 			flexDiv.appendChild(deleteIcon);
 
 			if(commentInfo.raidCommentDtoList[i].userId === userInfo.userId){
 				deleteIcon.style.display = 'block';
+				checkNum.style.display = 'none';
 			} else {
 				deleteIcon.style.display = 'none';
 			}
 
 
 	    } else {
-			if(commentInfo.raidCommentDtoList[i].raidCommentState === 'JOINED'){
-				nickDiv2.innerHTML += "<h5 class='nick1'>"+commentInfo.raidCommentDtoList[i].nickname1+"'s</5>";
-				showNick(commentInfo.raidCommentDtoList[i]);
-				nickDiv2.style.display = 'block'
+
+			let deleteIcon = '';
+
+			if (commentInfo.raidCommentDtoList[i].userId === userInfo.userId) {
+				deleteIcon = '<i class="fas fa-times delete" onClick="deleteComment()"></i><div> </div>';
 			}
-			checkNum.style.display = 'none';
+
+			nickDiv2.innerHTML += '<div class="d-flex flex-row align-items-center justify-content-between">'
+			+ '<h5 class="nick1">'+commentInfo.raidCommentDtoList[i].nickname1+'</h5>'
+			+ deleteIcon
+			+ '</div>';
+			showNick(commentInfo.raidCommentDtoList[i]);
+			nickDiv2.style.display = 'block'
 		}
       }
 
@@ -630,14 +638,22 @@ function endPost(num, chat) {
 //deleteComment() : 댓글 지우는 기능
 /* session에 있는 nickname1과 mypost에 떠있는 포스트 작성자의 nickname1이
 같을 경우에만 X 버튼 활성화 */
-function deleteComment(c_id, p_id){
+function deleteComment(){
 	if(confirm("Do you really want to erase it?")){
-	  const addData = { c_id : c_id }
-	  const strObject = JSON.stringify(addData);
-	  console.log(strObject);
-	
-	  const url = '/mypost/mycomment';
-	  sendAjax(url, 'DELETE', strObject);
+	  const url = '/api/mypost/comment';
+	  fetch(url, {
+		  method: "DELETE",
+		  headers: {
+			  "Content-type": "application/json",
+		  },
+	  })
+		  .then((response) => {
+			  if (response.status === 200) {
+				  alert('success');
+			  } else {
+				  alert('fail');
+			  }
+		  })
 	  setTimeout("location.reload()", 1000);
 	}
 }


### PR DESCRIPTION
- 초대중일때 종료시 좋아요싫어요 없이 바로 종료
- 진행중일때 종료시 좋아요싫어요 투표 진행
- 팀원이 본인 댓글만 종료처리 기능 구현